### PR TITLE
Do not write when queue is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,8 +132,13 @@ KinesisWritable.prototype.writeRecords = function writeRecords(callback) {
  *
  * @private
  * @param {Function} callback
+ * @return {undefined}
  */
 KinesisWritable.prototype._flush = function _flush(callback) {
+    if (this.queue.length === 0) {
+        return callback();
+    }
+
     var retry = retryFn.bind(null, {
         retries: this.maxRetries,
         timeout: retryFn.fib(this.retryTimeout)

--- a/test/kinesis-write-stream.js
+++ b/test/kinesis-write-stream.js
@@ -86,6 +86,22 @@ describe('KinesisWritable', function() {
                 .pipe(this.stream);
         });
 
+        it('should do nothing if there is nothing in the queue when the stream is closed', function(done) {
+            this.client.putRecords.yields(null, successResponseFixture);
+
+            this.stream.on('finish', function() {
+                expect(this.client.putRecords).to.have.been.calledOnce;
+
+                done();
+            }.bind(this));
+
+            for (var i = 0; i < 6; i++) {
+                this.stream.write(recordsFixture);
+            }
+
+            this.stream.end();
+        });
+
         it('should buffer records up to highWaterMark', function(done) {
             this.client.putRecords.yields(null, successResponseFixture);
 


### PR DESCRIPTION
If the queue is empty we shouldn't try to write to Kinesis when the stream closes