### PR TITLE
Ensure record is passed to getPartitionKey helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ KinesisWritable.prototype.getPartitionKey = function getPartitionKey(record) {
 KinesisWritable.prototype.transformRecord = function transformRecord(record) {
     return {
         Data: JSON.stringify(record),
-        PartitionKey: this.getPartitionKey()
+        PartitionKey: this.getPartitionKey(record)
     };
 };
 


### PR DESCRIPTION
The documentation states that the record is passed to the getPartitionKey helper however this is not the case.

This change amends the code to reflect the documentation and adds additional tests