### PR TITLE
Added support for options.flushTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ reached. The initial timeout before the retry is set in
 The partition key is by default a random number, but this can be
 adjusted by overriding `streamInstance.getPartitionKey(record)`.
 
+## Flushing
+
+Its also possible to send in the option `flushTimeout` to indicate
+that the items currently in the buffer should be flushed after the
+given amount of milliseconds if the `highWaterMark` haven't been
+reached.
+
 ## Logging
 
 A [bunyan](https://www.npmjs.com/package/bunyan),

--- a/api.md
+++ b/api.md
@@ -2,7 +2,7 @@
 ## KinesisWritable(client, streamName, options)
 A simple stream wrapper around Kinesis putRecords
 
-**Kind**: global function  
+**Kind**: global function
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -12,15 +12,15 @@ A simple stream wrapper around Kinesis putRecords
 | [options.highWaterMark] | <code>number</code> | <code>16</code> | Number of items to buffer before writing. Also the size of the underlying stream buffer. |
 | [options.maxRetries] | <code>Number</code> | <code>3</code> | How many times to retry failed data before rasing an error |
 | [options.retryTimeout] | <code>Number</code> | <code>100</code> | How long to wait initially before retrying failed records |
+| [options.flushTimeout] | <code>number</code> | <code></code> | Number of ms to flush records after, if highWaterMark hasn't been reached |
 | [options.logger] | <code>Object</code> |  | Instance of a logger like bunyan or winston |
 
 <a name="KinesisWritable+getPartitionKey"></a>
 ### kinesisWritable.getPartitionKey([record]) ⇒ <code>string</code>
 Get partition key for given record
 
-**Kind**: instance method of <code>[KinesisWritable](#KinesisWritable)</code>  
+**Kind**: instance method of <code>[KinesisWritable](#KinesisWritable)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [record] | <code>Object</code> | Record |
-


### PR DESCRIPTION
@voldern following on from the discussion in #4 I've gone ahead and implemented this feature based upon your approach in [voldern/elasticsearch-writable-stream](http://github.com/voldern/elasticsearch-writable-stream)

I had to tweak the fush timeout tests however due to the use of `retry-fn` which itself uses timers. 